### PR TITLE
setup.py: remove hamiltonian package to fix build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(name='nested_sampling',
 		'nested_sampling',
 		'nested_sampling.samplers',
 		'nested_sampling.clustering',
-		'nested_sampling.samplers.svm',
-		'nested_sampling.samplers.hamiltonian',
+		'nested_sampling.samplers.svm'
 	],
 	)
 


### PR DESCRIPTION
The `'nested_sampling.samplers.hamiltonian'` listed in `setup.py` does not exist, so the package won't build. This patch fixes that by removing the offending line.